### PR TITLE
fixing referrer in tests, fixing ipaddress, adding support for custom tracking server URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var _persistEvars = true;
 var _sProps = [];
 var _persistSProps = false;
 var _reportingSuiteId=null;
+var _trackingServerUrl=null;
 var _persistReportingSuiteId=true;
 var _pageName=null;
 var _persistPageName=true;
@@ -119,7 +120,7 @@ function _sendCallToAdobeAnalytics(di, logger){
     var body = _xmlPre + di.getPostXmlRequestBody() + _xmlPost;
     //console.info(body);
     var call_options = {
-        host: self.getReportingSuiteId()+".112.2o7.net",
+        host: self.getTrackingServerUrl() || self.getReportingSuiteId()+".112.2o7.net",
         port: 80,
         path: '/b/ss//6',
         method: 'POST',
@@ -331,6 +332,26 @@ var AdobeAnalyticsHelper = {
      */
     getReportingSuiteId:function(){
         return _reportingSuiteId;
+    },
+    /**
+     * @doc setTrackingServerUrl
+     * @name AdobeAnalyticsHelper:setTrackingServerUrl
+     *
+     * @description sets the tracking server url
+     *
+     */
+    setTrackingServerUrl: function (trackingServerUrl) {
+        _trackingServerUrl = trackingServerUrl
+    },
+    /**
+     * @doc getTrackingServerUrl
+     * @name AdobeAnalyticsHelper:getTrackingServerUrl
+     *
+     * @description gets the tracking server url
+     *
+     */
+    getTrackingServerUrl:function(){
+        return _trackingServerUrl;
     },
     /**
      * @doc getDataInsertion

--- a/index.js
+++ b/index.js
@@ -250,15 +250,15 @@ function DataInsertion(data){
     }
 
     //visitor id or ipAddress is required
-    if(typeof data.IPaddress == 'undefined'){
+    if(typeof data.ipaddress == 'undefined'){
         if((typeof _defaultIpAddress != 'undefined') && (_defaultIpAddress != null)){
-            data['IPaddress'] = _defaultIpAddress;
+            data['ipaddress'] = _defaultIpAddress;
         }
     }
 
     //check either ip or visitor is defined
-    if((typeof data.visitorID == 'undefined') && (typeof data.IPaddress == 'undefined')){
-        throw new Error('visitorID OR IPaddress must be defined');
+    if((typeof data.visitorID == 'undefined') && (typeof data.ipaddress == 'undefined')){
+        throw new Error('visitorID OR ipaddress must be defined');
     }
 
     //Page name or page url is required

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,11 @@ it('should set reporting suite ID', function () {
     adobeAnalyticsHelper.getReportingSuiteId().should.equal("MY-REPORTING-SUITE-ID")
 });
 
+it('should set reporting suite ID', function () {
+    adobeAnalyticsHelper.setTrackingServerUrl("custom.tracking.com");
+    adobeAnalyticsHelper.getTrackingServerUrl().should.equal("custom.tracking.com")
+});
+
 it('should create a DI xml object to post (using visitorID)', function () {
     var callData = {
         visitorID: 'myvisitorId',

--- a/test/index.js
+++ b/test/index.js
@@ -19,10 +19,10 @@ it('should create a DI xml object to post (using visitorID)', function () {
         eVar10: 'test evar10 value',
         prop10: 'test prop10 value',
         events: "event10,event11",
-        referrer: adobeAnalyticsHelper.getReportingSuiteId()
+        referrer: "https://dummy.referrer.com"
     };
 
-    var testResult = '<visitorID>myvisitorId</visitorID><pageName>My Home Page</pageName><channel>My Channel name</channel><eVar10>test evar10 value</eVar10><prop10>test prop10 value</prop10><events>event10,event11</events><referrer>MY-REPORTING-SUITE-ID</referrer><reportSuiteID>MY-REPORTING-SUITE-ID</reportSuiteID>';
+    var testResult = '<visitorID>myvisitorId</visitorID><pageName>My Home Page</pageName><channel>My Channel name</channel><eVar10>test evar10 value</eVar10><prop10>test prop10 value</prop10><events>event10,event11</events><referrer>https://dummy.referrer.com</referrer><reportSuiteID>MY-REPORTING-SUITE-ID</reportSuiteID>';
 
     var myDi = adobeAnalyticsHelper.getDataInsertion(callData);
 
@@ -37,10 +37,10 @@ it('should create a DI xml object to post (using ipaddress)', function () {
         eVar10: 'test evar10 value',
         prop10: 'test prop10 value',
         events: "event10,event11",
-        referrer: adobeAnalyticsHelper.getReportingSuiteId()
+        referrer: "https://dummy.referrer.com"
     };
 
-    var testResult = '<ipaddress>127.0.0.1</ipaddress><pageName>My Home Page</pageName><channel>My Channel name</channel><eVar10>test evar10 value</eVar10><prop10>test prop10 value</prop10><events>event10,event11</events><referrer>MY-REPORTING-SUITE-ID</referrer><reportSuiteID>MY-REPORTING-SUITE-ID</reportSuiteID>';
+    var testResult = '<ipaddress>127.0.0.1</ipaddress><pageName>My Home Page</pageName><channel>My Channel name</channel><eVar10>test evar10 value</eVar10><prop10>test prop10 value</prop10><events>event10,event11</events><referrer>https://dummy.referrer.com</referrer><reportSuiteID>MY-REPORTING-SUITE-ID</reportSuiteID>';
 
     var myDi = adobeAnalyticsHelper.getDataInsertion(callData);
 

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,7 @@ it('should set reporting suite ID', function () {
     adobeAnalyticsHelper.getReportingSuiteId().should.equal("MY-REPORTING-SUITE-ID")
 });
 
-it('should create a DI xml object to post', function () {
+it('should create a DI xml object to post (using visitorID)', function () {
     var callData = {
         visitorID: 'myvisitorId',
         pageName: 'My Home Page',
@@ -18,6 +18,24 @@ it('should create a DI xml object to post', function () {
     };
 
     var testResult = '<visitorID>myvisitorId</visitorID><pageName>My Home Page</pageName><channel>My Channel name</channel><eVar10>test evar10 value</eVar10><prop10>test prop10 value</prop10><events>event10,event11</events><referrer>MY-REPORTING-SUITE-ID</referrer><reportSuiteID>MY-REPORTING-SUITE-ID</reportSuiteID>';
+
+    var myDi = adobeAnalyticsHelper.getDataInsertion(callData);
+
+    myDi.getPostXmlRequestBody().should.equal(testResult);
+});
+
+it('should create a DI xml object to post (using ipaddress)', function () {
+    var callData = {
+        ipaddress: '127.0.0.1',
+        pageName: 'My Home Page',
+        channel: 'My Channel name',
+        eVar10: 'test evar10 value',
+        prop10: 'test prop10 value',
+        events: "event10,event11",
+        referrer: adobeAnalyticsHelper.getReportingSuiteId()
+    };
+
+    var testResult = '<ipaddress>127.0.0.1</ipaddress><pageName>My Home Page</pageName><channel>My Channel name</channel><eVar10>test evar10 value</eVar10><prop10>test prop10 value</prop10><events>event10,event11</events><referrer>MY-REPORTING-SUITE-ID</referrer><reportSuiteID>MY-REPORTING-SUITE-ID</reportSuiteID>';
 
     var myDi = adobeAnalyticsHelper.getDataInsertion(callData);
 

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,8 @@ it('should create a DI xml object to post', function () {
         channel: 'My Channel name',
         eVar10: 'test evar10 value',
         prop10: 'test prop10 value',
-        events: "event10,event11"
+        events: "event10,event11",
+        referrer: adobeAnalyticsHelper.getReportingSuiteId()
     };
 
     var testResult = '<visitorID>myvisitorId</visitorID><pageName>My Home Page</pageName><channel>My Channel name</channel><eVar10>test evar10 value</eVar10><prop10>test prop10 value</prop10><events>event10,event11</events><referrer>MY-REPORTING-SUITE-ID</referrer><reportSuiteID>MY-REPORTING-SUITE-ID</reportSuiteID>';


### PR DESCRIPTION
(fixed) test was failing on referrer (probably due to v 1.2.1 fix
(fixed) DI object creation was failing if ipaddress was used instead of visitorID (case mismatch)
(added) support for setting a custom tracking server URL