### PR TITLE
Adding support for AAM SSF

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ var _parameters = {
     hier:{postParam:"hier",description:'A hierarchy string.',multiform:true,max:5,getParam:"h"},
     homePage:{postParam:"homePage",description:'Whether the current page is the visitors homepage (Y or N).',multiform:false,getParam:"hp"},
     ipaddress:{postParam:"ipaddress",description:'The visitors IP address.',multiform:false,getParam:""},
+    imsregion:{postParam:"imsregion",description:'The Location Hint from Visitor ID Service.',multiform:false,getParam:""},
     javaEnabled:{postParam:"javaEnabled",description:'Whether the visitor has Java enabled (Y or N).',multiform:false,getParam:"v"},
     javaScriptVersion:{postParam:"javaScriptVersion",description:'JavaScript version. For example, 1.3.',multiform:false,getParam:"j"},
     language:{postParam:"language",description:'The browsers supported language. For example, "en-us".',multiform:false,getParam:""},

--- a/test/index.js
+++ b/test/index.js
@@ -46,3 +46,22 @@ it('should create a DI xml object to post (using ipaddress)', function () {
 
     myDi.getPostXmlRequestBody().should.equal(testResult);
 });
+
+it('should create a DI xml object to post and SSF (using imsregion)', function () {
+    var callData = {
+        ipaddress: '127.0.0.1',
+        imsregion: '8',
+        pageName: 'My Home Page',
+        channel: 'My Channel name',
+        eVar10: 'test evar10 value',
+        prop10: 'test prop10 value',
+        events: "event10,event11",
+        referrer: "https://dummy.referrer.com"
+    };
+
+    var testResult = '<ipaddress>127.0.0.1</ipaddress><imsregion>8</imsregion><pageName>My Home Page</pageName><channel>My Channel name</channel><eVar10>test evar10 value</eVar10><prop10>test prop10 value</prop10><events>event10,event11</events><referrer>https://dummy.referrer.com</referrer><reportSuiteID>MY-REPORTING-SUITE-ID</reportSuiteID>';
+
+    var myDi = adobeAnalyticsHelper.getDataInsertion(callData);
+
+    myDi.getPostXmlRequestBody().should.equal(testResult);
+});


### PR DESCRIPTION
As per the latest Insertion API spec the 'imsregion' property is required to trigger a SSF call to AAM. This pull request adds the 'imsregion' property in the implementation.